### PR TITLE
Add child chat and story models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -161,3 +161,75 @@ enum TeamRole {
   MEMBER
   OWNER
 }
+
+model Child {
+  id          String   @id @default(cuid())
+  userId      String
+  name        String
+  birthDate   DateTime
+  preferences Json?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user       User         @relation(fields: [userId], references: [id])
+  sessions   ChatSession[]
+  stories    Story[]
+
+  @@index([userId])
+  @@map("children")
+}
+
+model ChatSession {
+  id        String   @id @default(cuid())
+  childId   String
+  startedAt DateTime @default(now())
+  endedAt   DateTime?
+
+  child    Child        @relation(fields: [childId], references: [id])
+  messages ChatMessage[]
+
+  @@index([childId])
+  @@map("chatSessions")
+}
+
+model ChatMessage {
+  id           String   @id @default(cuid())
+  chatSessionId String
+  sender       MessageSender
+  content      String
+  createdAt    DateTime @default(now())
+  memoryRef    String?
+
+  session ChatSession @relation(fields: [chatSessionId], references: [id])
+
+  @@index([chatSessionId])
+  @@map("chatMessages")
+}
+
+model Story {
+  id            String   @id @default(cuid())
+  childId       String
+  title         String
+  content       String
+  status        StoryStatus @default(DRAFT)
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+  parentStoryId String?
+
+  child       Child  @relation(fields: [childId], references: [id])
+  parentStory Story? @relation("StoryHierarchy", fields: [parentStoryId], references: [id])
+  chapters    Story[] @relation("StoryHierarchy")
+
+  @@index([childId])
+  @@map("stories")
+}
+
+enum MessageSender {
+  child
+  ai
+}
+
+enum StoryStatus {
+  DRAFT
+  PUBLISHED
+}

--- a/prisma/services/chat.js
+++ b/prisma/services/chat.js
@@ -1,0 +1,30 @@
+import prisma from '@/prisma/index';
+
+export const createChatSession = async (childId) =>
+  await prisma.chatSession.create({
+    data: {
+      childId,
+    },
+  });
+
+export const endChatSession = async (sessionId) =>
+  await prisma.chatSession.update({
+    data: { endedAt: new Date() },
+    where: { id: sessionId },
+  });
+
+export const addMessage = async (chatSessionId, sender, content, memoryRef) =>
+  await prisma.chatMessage.create({
+    data: {
+      chatSessionId,
+      sender,
+      content,
+      memoryRef,
+    },
+  });
+
+export const getSessionMessages = async (chatSessionId) =>
+  await prisma.chatMessage.findMany({
+    where: { chatSessionId },
+    orderBy: { createdAt: 'asc' },
+  });

--- a/prisma/services/child.js
+++ b/prisma/services/child.js
@@ -1,0 +1,16 @@
+import prisma from '@/prisma/index';
+
+export const createChild = async (userId, name, birthDate, preferences) =>
+  await prisma.child.create({
+    data: {
+      userId,
+      name,
+      birthDate,
+      preferences,
+    },
+  });
+
+export const getChildren = async (userId) =>
+  await prisma.child.findMany({
+    where: { userId },
+  });

--- a/prisma/services/story.js
+++ b/prisma/services/story.js
@@ -1,0 +1,23 @@
+import prisma from '@/prisma/index';
+
+export const createStory = async (childId, title, content, parentStoryId) =>
+  await prisma.story.create({
+    data: {
+      childId,
+      title,
+      content,
+      parentStoryId,
+    },
+  });
+
+export const updateStoryStatus = async (storyId, status) =>
+  await prisma.story.update({
+    data: { status },
+    where: { id: storyId },
+  });
+
+export const getStories = async (childId) =>
+  await prisma.story.findMany({
+    where: { childId },
+    orderBy: { createdAt: 'asc' },
+  });

--- a/src/lib/server/mem0.js
+++ b/src/lib/server/mem0.js
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+const MEM0_API_URL = process.env.MEM0_API_URL;
+const MEM0_API_KEY = process.env.MEM0_API_KEY;
+
+export const saveMemory = async (payload) => {
+  if (!MEM0_API_URL || !MEM0_API_KEY) {
+    throw new Error('mem0 not configured');
+  }
+  const result = await axios.post(`${MEM0_API_URL}/memory`, payload, {
+    headers: { Authorization: MEM0_API_KEY },
+  });
+  return result.data;
+};
+
+export const searchMemory = async (payload) => {
+  if (!MEM0_API_URL || !MEM0_API_KEY) {
+    throw new Error('mem0 not configured');
+  }
+  const result = await axios.post(`${MEM0_API_URL}/search`, payload, {
+    headers: { Authorization: MEM0_API_KEY },
+  });
+  return result.data;
+};

--- a/src/pages/api/chat/message/add.js
+++ b/src/pages/api/chat/message/add.js
@@ -1,0 +1,14 @@
+import { validateSession } from '@/config/api-validation';
+import { addMessage } from '@/prisma/services/chat';
+
+export default async function handler(req, res) {
+  const { method } = req;
+  if (method !== 'POST') {
+    res.status(405).json({ error: `${method} method unsupported` });
+    return;
+  }
+  await validateSession(req, res);
+  const { chatSessionId, sender, content, memoryRef } = req.body;
+  const message = await addMessage(chatSessionId, sender, content, memoryRef);
+  res.status(200).json({ data: { message } });
+}

--- a/src/pages/api/chat/session/create.js
+++ b/src/pages/api/chat/session/create.js
@@ -1,0 +1,14 @@
+import { validateSession } from '@/config/api-validation';
+import { createChatSession } from '@/prisma/services/chat';
+
+export default async function handler(req, res) {
+  const { method } = req;
+  if (method !== 'POST') {
+    res.status(405).json({ error: `${method} method unsupported` });
+    return;
+  }
+  await validateSession(req, res);
+  const { childId } = req.body;
+  const session = await createChatSession(childId);
+  res.status(200).json({ data: { session } });
+}

--- a/src/pages/api/child/create.js
+++ b/src/pages/api/child/create.js
@@ -1,0 +1,19 @@
+import { validateSession } from '@/config/api-validation';
+import { createChild } from '@/prisma/services/child';
+
+export default async function handler(req, res) {
+  const { method } = req;
+  if (method !== 'POST') {
+    res.status(405).json({ error: `${method} method unsupported` });
+    return;
+  }
+  const session = await validateSession(req, res);
+  const { name, birthDate, preferences } = req.body;
+  const child = await createChild(
+    session.user.userId,
+    name,
+    new Date(birthDate),
+    preferences
+  );
+  res.status(200).json({ data: { child } });
+}

--- a/src/pages/api/story/save.js
+++ b/src/pages/api/story/save.js
@@ -1,0 +1,22 @@
+import { validateSession } from '@/config/api-validation';
+import { createStory, updateStoryStatus } from '@/prisma/services/story';
+
+export default async function handler(req, res) {
+  const { method } = req;
+  if (method !== 'POST') {
+    res.status(405).json({ error: `${method} method unsupported` });
+    return;
+  }
+  await validateSession(req, res);
+  const { childId, title, content, parentStoryId, storyId, publish } = req.body;
+  let story;
+  if (storyId) {
+    story = await updateStoryStatus(storyId, publish ? 'PUBLISHED' : 'DRAFT');
+  } else {
+    story = await createStory(childId, title, content, parentStoryId);
+    if (publish) {
+      story = await updateStoryStatus(story.id, 'PUBLISHED');
+    }
+  }
+  res.status(200).json({ data: { story } });
+}


### PR DESCRIPTION
## Summary
- add models for Child, ChatSession, ChatMessage and Story in Prisma schema
- add service layer for managing children, chat, and stories
- add basic API routes for creating children, sessions, messages and saving stories
- stub out mem0 client helper

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a868cd3c8332a4a6a555aff6d466