### PR TITLE
Fix global CSS import

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -12,7 +12,7 @@ import progressBarConfig from '@/config/progress-bar/index';
 import swrConfig from '@/config/swr/index';
 import WorkspaceProvider from '@/providers/workspace';
 
-import '@/styles/globals.css';
+import '../styles/globals.css';
 let rawdata = require('../messages/en.json');
 
 let langCode = "en"


### PR DESCRIPTION
## Summary
- fix global CSS import path for Next.js 15

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879e6ebfc688332b400d11b3131d529