### PR TITLE
Fix session check

### DIFF
--- a/src/lib/server/auth.js
+++ b/src/lib/server/auth.js
@@ -15,6 +15,7 @@ export const authOptions = {
       if (session.user) {
         const customerPayment = await getPayment(user.email);
         session.user.userId = user.id;
+        session.user.id = user.id;
 
         if (customerPayment) {
           session.user.subscription = customerPayment.subscriptionType;


### PR DESCRIPTION
## Summary
- properly set `session.user.id` alongside `userId` when building session

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687dc94baf1c8332b33d6b370aa6d645