### PR TITLE
Add chat panel buttons

### DIFF
--- a/src/pages/account/[workspaceSlug]/stories.js
+++ b/src/pages/account/[workspaceSlug]/stories.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useRouter } from 'next/router';
 import AccountLayout from '@/layouts/AccountLayout';
 
@@ -5,17 +6,52 @@ function StoriesPage() {
   const router = useRouter();
   const { workspaceSlug } = router.query;
 
+  const [activeChat, setActiveChat] = useState(null);
+
   // TODO: integrate with real stories data
   const stories = [];
+
+  const toggleChat = (type) => {
+    setActiveChat((prev) => (prev === type ? null : type));
+  };
 
   return (
     <div className="p-6">
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-bold">儿童故事</h1>
-        <button className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
-          新建故事
-        </button>
+        <div className="flex space-x-2">
+          <button
+            className="bg-gray-200 px-4 py-2 rounded hover:bg-gray-300"
+            onClick={() => toggleChat('normal')}
+          >
+            Normal Chat
+          </button>
+          <button
+            className="bg-gray-200 px-4 py-2 rounded hover:bg-gray-300"
+            onClick={() => toggleChat('digital')}
+          >
+            Digital Human Chat
+          </button>
+          <button
+            className="bg-gray-200 px-4 py-2 rounded hover:bg-gray-300"
+            onClick={() => toggleChat('voice')}
+          >
+            Realtime Voice Chat
+          </button>
+          <button className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+            新建故事
+          </button>
+        </div>
       </div>
+      {activeChat === 'normal' && (
+        <div className="mb-4 p-4 border rounded">Normal Chat Panel</div>
+      )}
+      {activeChat === 'digital' && (
+        <div className="mb-4 p-4 border rounded">Digital Human Chat Panel</div>
+      )}
+      {activeChat === 'voice' && (
+        <div className="mb-4 p-4 border rounded">Realtime Voice Chat Panel</div>
+      )}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {stories.length > 0 ? stories.map(s => (
           <div key={s.id} className="bg-white rounded shadow p-4">


### PR DESCRIPTION
## Summary
- extend the Stories page with chat buttons
- show a matching chat panel when a button is clicked

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b732fb7d08332bbb2dd714043f017