### PR TITLE
Add Xiaoice chat component placeholder

### DIFF
--- a/src/components/XiaoiceChat.js
+++ b/src/components/XiaoiceChat.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+const XiaoiceChat = () => {
+  useEffect(() => {
+    // TODO: replace with actual Xiaoice iframe script provided by the user
+    const script = document.createElement('script');
+    script.src = 'XIAOICE_IFRAME_SCRIPT_URL';
+    script.async = true;
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div id="xiaoice-chat-container" />
+    </div>
+  );
+};
+
+export default XiaoiceChat;

--- a/src/sections/Hero.js
+++ b/src/sections/Hero.js
@@ -3,12 +3,15 @@ import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { useTranslation } from "react-i18next";
+import XiaoiceChat from '@/components/XiaoiceChat';
 
 const Hero = () => {
   const { status: sessionStatus } = useSession();
   const [showMenu, setMenuVisibility] = useState(false);
+  const [showChat, setShowChat] = useState(false);
 
   const toggleMenu = () => setMenuVisibility(!showMenu);
+  const handleDemoClick = () => setShowChat(true);
   const { t } = useTranslation();
 
   return (
@@ -61,10 +64,14 @@ const Hero = () => {
           <a className="px-10 py-3 text-center text-white bg-blue-600 rounded shadow hover:bg-blue-500">
             Get Started
           </a>
-          <a className="px-10 py-3 text-center text-blue-600 rounded shadow hover:bg-blue-50">
+          <button
+            onClick={handleDemoClick}
+            className="px-10 py-3 text-center text-blue-600 rounded shadow hover:bg-blue-50"
+          >
             Live Demo
-          </a>
+          </button>
         </div>
+        {showChat && <XiaoiceChat />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `XiaoiceChat` component with placeholder script
- show chat when `Live Demo` (button 2) is clicked in `Hero` section

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b7388f41c83329987fa8824d90e19