### PR TITLE
Embed Xiaoice chat widget

### DIFF
--- a/src/components/XiaoiceChat.js
+++ b/src/components/XiaoiceChat.js
@@ -2,21 +2,54 @@ import { useEffect } from 'react';
 
 const XiaoiceChat = () => {
   useEffect(() => {
-    // TODO: replace with actual Xiaoice iframe script provided by the user
     const script = document.createElement('script');
-    script.src = 'XIAOICE_IFRAME_SCRIPT_URL';
-    script.async = true;
+    const scriptContent = `
+!(function(window){
+const host="https://aibeings-agent.xiaoice.com",
+  url=host+'/AgentCustomer/d760954caae94d28b1d468692a3bc3ca?isPc=1&isAutoResize=1&closable=1';
+const wrapDiv=document.createElement('div');
+wrapDiv.id='xiaoice-agent-embed';
+const container=document.createElement('div');
+container.id='xiaoice-agent-container';
+const stylesheet=document.createElement('style');
+stylesheet.innerHTML='#xiaoice-agent-embed{z-index:9999;position:fixed;right:20px;bottom:40px;width:48px;height:48px;border-radius:50%;box-shadow:0px 8px 24px 0px rgba(0,0,0,0.12);background:url("https://aibeings-vip.oss-cn-beijing.aliyuncs.com/public/static/agent_avatar.png");background-size:cover;cursor:pointer}#xiaoice-agent-container{position:absolute;right:0;bottom:58px;border:0;border-radius:16px;box-shadow:0px 20px 20px 0px rgba(0,0,0,0.1);overflow:hidden}#xiaoice-agent-container.horizontal{height:366px;width:calc(366px*16/9)}#xiaoice-agent-container.vertical{height:680px;width:calc(680px*9/16)}#xiaoice-agent-container iframe{width:100%;height:100%;border:0}';
+const iframe=document.createElement('iframe');
+iframe.allowFullscreen=false;
+iframe.allow='microphone';
+iframe.src=url;
+window.addEventListener('message',(e)=>{
+  if(e.origin!==host)return;
+  if(e.data.action==='close'){
+    container.classList.toggle('vertical',false);
+    wrapDiv.removeChild(container);
+  }
+});
+container.appendChild(iframe);
+wrapDiv.appendChild(stylesheet);
+wrapDiv.addEventListener('click',()=>{
+  if(container.classList.contains('vertical')){
+    container.classList.toggle('vertical',false);
+    wrapDiv.removeChild(container);
+  }else{
+    container.classList.toggle('vertical',true);
+    wrapDiv.appendChild(container);
+  }
+});
+document.body.appendChild(wrapDiv);
+})(globalThis);
+    `;
+    script.innerHTML = scriptContent;
     document.body.appendChild(script);
     return () => {
       document.body.removeChild(script);
+      const existing = document.getElementById('xiaoice-agent-embed');
+      if (existing) {
+        document.body.removeChild(existing);
+      }
     };
   }, []);
 
-  return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
-      <div id="xiaoice-chat-container" />
-    </div>
-  );
+  return null;
 };
 
 export default XiaoiceChat;

--- a/src/pages/account/[workspaceSlug]/stories.js
+++ b/src/pages/account/[workspaceSlug]/stories.js
@@ -1,17 +1,23 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import AccountLayout from '@/layouts/AccountLayout';
+import XiaoiceChat from '@/components/XiaoiceChat';
 
 function StoriesPage() {
   const router = useRouter();
   const { workspaceSlug } = router.query;
 
   const [activeChat, setActiveChat] = useState(null);
+  const [showDigitalChat, setShowDigitalChat] = useState(false);
 
   // TODO: integrate with real stories data
   const stories = [];
 
   const toggleChat = (type) => {
+    if (type === 'digital') {
+      setShowDigitalChat(true);
+      return;
+    }
     setActiveChat((prev) => (prev === type ? null : type));
   };
 
@@ -26,12 +32,16 @@ function StoriesPage() {
           >
             Normal Chat
           </button>
-          <button
-            className="bg-gray-200 px-4 py-2 rounded hover:bg-gray-300"
-            onClick={() => toggleChat('digital')}
-          >
-            Digital Human Chat
-          </button>
+          {!showDigitalChat ? (
+            <button
+              className="bg-gray-200 px-4 py-2 rounded hover:bg-gray-300"
+              onClick={() => toggleChat('digital')}
+            >
+              Digital Human Chat
+            </button>
+          ) : (
+            <XiaoiceChat />
+          )}
           <button
             className="bg-gray-200 px-4 py-2 rounded hover:bg-gray-300"
             onClick={() => toggleChat('voice')}
@@ -45,9 +55,6 @@ function StoriesPage() {
       </div>
       {activeChat === 'normal' && (
         <div className="mb-4 p-4 border rounded">Normal Chat Panel</div>
-      )}
-      {activeChat === 'digital' && (
-        <div className="mb-4 p-4 border rounded">Digital Human Chat Panel</div>
       )}
       {activeChat === 'voice' && (
         <div className="mb-4 p-4 border rounded">Realtime Voice Chat Panel</div>


### PR DESCRIPTION
## Summary
- embed Xiaoice chat widget script
- use XiaoiceChat component in digital stories page
- show widget instead of a separate toggle button

## Testing
- `npm ci --legacy-peer-deps`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c0ddc00a483329345f650b3d39ae6