### PR TITLE
Fix nodemailer peer dependency conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ npm run dev
 - Express Validator - 7.2.1
 - Micro - 10.0.1
 - Next Themes - 0.4.6
-- Nodemailer - 7.0.5
+- Nodemailer - 6.10.1
 - React Copy to Clipboard - 5.1.0
 - React Google Analytics - 3.3.1
 - React Hot Toast - 2.5.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "next": "^15.4.2",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "nodemailer": "^7.0.5",
+        "nodemailer": "^6.10.1",
         "openai": "^5.11.0",
         "react": "^19.1.0",
         "react-copy-to-clipboard": "^5.1.0",
@@ -6001,9 +6001,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
-      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-IZXwsc4vAFIp2KueOEv8swHC3nYN8vJAxpqD8OHBHWyZMBJ2Z7DresAiQEpX0yi10u9PSHL70DWisNFZL4sWJg==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -11625,9 +11625,9 @@
       "dev": true
     },
     "nodemailer": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
-      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg=="
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-IZXwsc4vAFIp2KueOEv8swHC3nYN8vJAxpqD8OHBHWyZMBJ2Z7DresAiQEpX0yi10u9PSHL70DWisNFZL4sWJg=="
     },
     "normalize-range": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "next": "^15.4.2",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "nodemailer": "^7.0.5",
+    "nodemailer": "^6.10.1",
     "openai": "^5.11.0",
     "react": "^19.1.0",
     "react-copy-to-clipboard": "^5.1.0",


### PR DESCRIPTION
## Summary
- downgrade `nodemailer` to 6.10.1 to satisfy `next-auth` peer requirement
- update lockfile and README to reflect new version

## Testing
- `npm install` *(fails: ERESOLVE)*
- `npm install --legacy-peer-deps` *(fails due to network checksum errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c26cb6e0c8332a98a8e36a35e1d15