### PR TITLE
Improve RealtimeChat with transcript and messages

### DIFF
--- a/src/components/RealtimeChat/index.js
+++ b/src/components/RealtimeChat/index.js
@@ -3,6 +3,8 @@ import { useState, useRef } from 'react';
 const RealtimeChat = () => {
   const [recording, setRecording] = useState(false);
   const [response, setResponse] = useState('');
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
   const mediaRecorderRef = useRef(null);
   const abortRef = useRef(null);
 
@@ -25,24 +27,47 @@ const RealtimeChat = () => {
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
       let txt = '';
+      let eventName = '';
+      let transcript = '';
       while (true) {
         const { value, done } = await reader.read();
         if (done) break;
         const str = decoder.decode(value);
         str.split('\n').forEach(line => {
-          if (line.startsWith('data:')) {
+          if (line.startsWith('event:')) {
+            eventName = line.replace('event:', '').trim();
+          } else if (line.startsWith('data:')) {
             const data = line.replace('data:', '').trim();
-            if (data && data !== '[DONE]') {
+            if (!data) return;
+            if (eventName === 'transcript') {
               try {
                 const json = JSON.parse(data);
-                txt += json.choices?.[0]?.delta?.content || '';
+                transcript += json.delta || '';
+              } catch {}
+            } else if (eventName === 'transcript_done') {
+              try {
+                const json = JSON.parse(data);
+                transcript += json.transcript || '';
+              } catch {}
+              setMessages(prev => [...prev, { role: 'user', content: transcript }]);
+              transcript = '';
+            } else {
+              try {
+                const json = JSON.parse(data);
+                txt += json.text || json.choices?.[0]?.delta?.content || '';
               } catch {
                 txt += data;
               }
+              setResponse(txt);
             }
+            eventName = '';
           }
         });
-        setResponse(txt);
+      }
+      if (txt) {
+        setMessages(prev => [...prev, { role: 'assistant', content: txt }]);
+        const utter = new SpeechSynthesisUtterance(txt);
+        speechSynthesis.speak(utter);
       }
     };
     recorder.start();
@@ -67,15 +92,57 @@ const RealtimeChat = () => {
     setRecording(false);
   };
 
+  const sendText = async () => {
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', content: input.trim() };
+    setMessages(prev => [...prev, userMsg]);
+    setInput('');
+    const res = await fetch('/api/chat/openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: [...messages, userMsg] }),
+    });
+    const data = await res.json();
+    if (data.reply) {
+      setMessages(prev => [...prev, { role: 'assistant', content: data.reply }]);
+      const utter = new SpeechSynthesisUtterance(data.reply);
+      speechSynthesis.speak(utter);
+    }
+  };
+
   return (
     <div className="space-y-4">
-      <button onClick={recording ? stopRecording : startRecording} className="px-4 py-2 bg-blue-500 text-white rounded">
-        {recording ? 'Stop' : 'Record'}
-      </button>
-      <button onClick={interrupt} disabled={!abortRef.current} className="px-4 py-2 bg-red-500 text-white rounded disabled:opacity-50">
-        Interrupt
-      </button>
-      <pre className="p-2 bg-gray-100 rounded whitespace-pre-wrap">{response}</pre>
+      <div className="space-x-2">
+        <button onClick={recording ? stopRecording : startRecording} className="px-4 py-2 bg-blue-500 text-white rounded">
+          {recording ? 'Stop' : 'Record'}
+        </button>
+        <button onClick={interrupt} disabled={!abortRef.current} className="px-4 py-2 bg-red-500 text-white rounded disabled:opacity-50">
+          Interrupt
+        </button>
+      </div>
+      <div className="h-64 overflow-y-auto p-2 bg-gray-100 rounded">
+        {messages.map((m, i) => (
+          <div key={i} className="mb-2">
+            <strong>{m.role === 'assistant' ? 'AI:' : 'Me:'}</strong> {m.content}
+          </div>
+        ))}
+        {response && (
+          <div className="mb-2 text-blue-600">
+            <strong>AI:</strong> {response}
+          </div>
+        )}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="flex-1 border rounded p-2"
+          placeholder="Type your message..."
+        />
+        <button onClick={sendText} className="px-4 py-2 bg-blue-500 text-white rounded">
+          Send
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/pages/api/chat/realtime.js
+++ b/src/pages/api/chat/realtime.js
@@ -44,6 +44,14 @@ export default async function handler(req, res) {
     res.write(`data: ${JSON.stringify({ text: event.delta })}\n\n`);
   });
 
+  rt.on('conversation.item.input_audio_transcription.delta', (event) => {
+    res.write(`event: transcript\ndata: ${JSON.stringify({ delta: event.delta })}\n\n`);
+  });
+
+  rt.on('conversation.item.input_audio_transcription.completed', (event) => {
+    res.write(`event: transcript_done\ndata: ${JSON.stringify({ transcript: event.transcript })}\n\n`);
+  });
+
   const close = () => {
     if (rt) rt.close();
     res.end();


### PR DESCRIPTION
## Summary
- expose transcription events from realtime chat API
- stream transcript and assistant messages in RealtimeChat UI
- add text input fallback and speech synthesis of replies

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c38f2398c8332b09e8765eff52c99