### PR TITLE
Fix OpenAI API version configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cp .env.sample .env
 .env.sample 文件中还包含与 AI 集成相关的变量：
 
 - `AZURE_OPENAI_KEY` 与 `AZURE_OPENAI_ENDPOINT`：Azure OpenAI 服务的 API 密钥和访问路径。
+- `AZURE_OPENAI_API_VERSION`：Azure OpenAI 服务的 API 版本，若未设置将默认使用 `2024-02-15-preview`。
 - `AZURE_REALTIME_KEY`：Azure 实时服务的密钥。
 - `XIAOBING_API_KEY`：用于访问小冰数字人 API 的 Key。
 

--- a/src/pages/api/chat/openai.js
+++ b/src/pages/api/chat/openai.js
@@ -26,6 +26,8 @@ export default async function handler(req, res) {
   const endpoint = process.env.AZURE_OPENAI_ENDPOINT;
   const deployment = process.env.AZURE_OPENAI_DEPLOYMENT;
   const apiKey = process.env.AZURE_OPENAI_API_KEY;
+  const apiVersion = process.env.AZURE_OPENAI_API_VERSION ||
+    '2024-02-15-preview';
 
   if (!endpoint || !deployment || !apiKey) {
     res.status(500).json({ error: 'Azure OpenAI environment not configured' });
@@ -33,7 +35,7 @@ export default async function handler(req, res) {
   }
 
   try {
-    const url = `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=2024-02-15-preview`;
+    const url = `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`;
     const response = await axios.post(
       url,
       {


### PR DESCRIPTION
## Summary
- make the OpenAI chat API use `AZURE_OPENAI_API_VERSION` env var
- document the new variable in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c7a99049c8332aa4513028f0b6217