### PR TITLE
feat: label realtime chat speakers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "jest",
     "postinstall": "prisma generate"
   },
   "prisma": {
@@ -51,6 +52,9 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9.31.0",
     "eslint-config-next": "^15.4.2",
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/react": "^14.1.2",
+    "jest": "^29.7.0",
     "postcss": "^8.5.6",
     "prisma": "^6.12.0",
     "tailwindcss": "^4.1.11"

--- a/src/components/AzureRealtimeChat/index.js
+++ b/src/components/AzureRealtimeChat/index.js
@@ -1,9 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 
-const AzureRealtimeChat = () => {
+const AzureRealtimeChat = ({ initialMessages = [], initialResponse = '' }) => {
   const [recording, setRecording] = useState(false);
-  const [response, setResponse] = useState('');
-  const [messages, setMessages] = useState([]);
+  const [response, setResponse] = useState(initialResponse);
+  const [messages, setMessages] = useState(initialMessages);
   const [input, setInput] = useState('');
   const pcRef = useRef(null);
   const dcRef = useRef(null);
@@ -199,19 +199,29 @@ const AzureRealtimeChat = () => {
       <div className="flex-1 overflow-y-auto p-4 space-y-4 bg-gray-50 rounded">
         {messages.map((m, i) => (
           <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-            <div
-              className={`px-3 py-2 rounded-lg max-w-lg whitespace-pre-line ${
-                m.role === 'user' ? 'bg-blue-500 text-white' : 'bg-white text-gray-900 border'
-              }`}
-            >
-              {m.content}
+            <div className="flex flex-col max-w-lg">
+              <span className="text-xs text-gray-500 mb-1">
+                {m.role === 'user' ? 'You' : 'Assistant'}
+              </span>
+              <div
+                className={`px-3 py-2 rounded-lg whitespace-pre-line ${
+                  m.role === 'user'
+                    ? 'bg-blue-500 text-white'
+                    : 'bg-white text-gray-900 border'
+                }`}
+              >
+                {m.content}
+              </div>
             </div>
           </div>
         ))}
         {response && (
           <div className="flex justify-start">
-            <div className="px-3 py-2 rounded-lg max-w-lg whitespace-pre-line bg-white text-gray-900 border">
-              {response}
+            <div className="flex flex-col max-w-lg">
+              <span className="text-xs text-gray-500 mb-1">Assistant</span>
+              <div className="px-3 py-2 rounded-lg whitespace-pre-line bg-white text-gray-900 border">
+                {response}
+              </div>
             </div>
           </div>
         )}

--- a/src/components/AzureRealtimeChat/index.test.js
+++ b/src/components/AzureRealtimeChat/index.test.js
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import AzureRealtimeChat from './index';
+
+describe('AzureRealtimeChat', () => {
+  it('renders speaker labels for user and assistant messages', () => {
+    render(
+      <AzureRealtimeChat
+        initialMessages={[
+          { role: 'user', content: 'Hi' },
+          { role: 'assistant', content: 'Hello there' }
+        ]}
+      />
+    );
+
+    expect(screen.getByText('You')).toBeInTheDocument();
+    expect(screen.getAllByText('Assistant')[0]).toBeInTheDocument();
+  });
+
+  it('renders streaming response with assistant label', () => {
+    render(<AzureRealtimeChat initialResponse="Typing..." />);
+    expect(screen.getByText('Assistant')).toBeInTheDocument();
+    expect(screen.getByText('Typing...')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- allow injecting preset messages in realtime chat for testing
- add jest tests asserting 'You' and 'Assistant' labels

## Testing
- `npm test` (fails: jest: not found)
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_6892f7ffffcc8332aaba7b6999bd9297