### PR TITLE
feat: integrate flowise tools into realtime chat

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -49,3 +49,8 @@ AZURE_OPENAI_REALTIME_REGION= # e.g. eastus2 -> https://eastus2.realtimeapi-prev
 AZURE_REALTIME_KEY = # Azure realtime service key
 XIAOBING_API_KEY = # API key for Xiaoice
 
+# Flowise Configuration
+NEXT_PUBLIC_FLOWISE_BASE_URL=
+NEXT_PUBLIC_FLOWISE_API_KEY=
+NEXT_PUBLIC_FLOWISE_CHATFLOW_ID=
+


### PR DESCRIPTION
## Summary
- fetch Flowise chatflow tools and register them in Azure Realtime chat
- handle tool calls via Flowise endpoints and expose config env vars

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689596ff41e88332860b28d74e1a72c3