### PR TITLE
fix: disable speech when not in voice mode

### DIFF
--- a/src/components/AzureTextChat/index.js
+++ b/src/components/AzureTextChat/index.js
@@ -273,7 +273,9 @@ const AzureTextChat = () => {
       if (data.reply) {
         const updated = [...history, { role: 'assistant', content: data.reply }];
         setMessages(updated);
-        await speak(data.reply);
+        if (voiceMode) {
+          await speak(data.reply);
+        }
       }
       if (provider === 'dify' && data.conversation_id) {
         setConversationId(data.conversation_id);


### PR DESCRIPTION
## Summary
- only trigger speech synthesis when voice mode is active in AzureTextChat

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_689825dbab84833286611333750d1856